### PR TITLE
allow for comma-delimited na_value input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG THEIAVALIDATE_VER="1.1.2"
+ARG THEIAVALIDATE_VER="1.1.3"
 
 FROM google/cloud-sdk:455.0.0-slim 
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-__VERSION__ = "v1.1.2"
+__VERSION__ = "v1.1.3"
 import os
 import sys
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))

--- a/theiavalidate/__init__.py
+++ b/theiavalidate/__init__.py
@@ -1,4 +1,4 @@
-__VERSION__ = "v1.1.2"
+__VERSION__ = "v1.1.3"
 
 import os
 import sys

--- a/theiavalidate/theiavalidate.py
+++ b/theiavalidate/theiavalidate.py
@@ -33,14 +33,18 @@ def main():
     parser.add_argument("-o", "--output_prefix",
                         help="the output file name prefix\ndo not include any spaces", default="theiavalidate", metavar="\b")
     parser.add_argument("-n", "--na_values",
-                        help=f"the values that should be considered NA\ndefault values = {DEFAULT_NA_VALUES}",
-                        default=DEFAULT_NA_VALUES, metavar="\b", type=int)
+                        help=f"a comma-delimited string of values that should be considered NA\ndefault values = {DEFAULT_NA_VALUES}",
+                        default=DEFAULT_NA_VALUES, metavar="\b")
     parser.add_argument("--verbose",
                         help="increase stdout verbosity", action="store_true", default=False)
     parser.add_argument("--debug",
                         help="increase stdout verbosity to debug; overwrites --verbose", action="store_true", default=False)
 
     options = parser.parse_args()
+
+    # convert string inputs to a list
+    if isinstance(parser.na_values, str):
+        parser.na_values=na_values.split(',')
 
     validate = Validator(options)
     validate.compare()


### PR DESCRIPTION
na_values cannot be modified because they are restricted to integer type input and are not split into a list. This PR enables a comma-delimited string input 